### PR TITLE
Allow reusable workflows to select runner labels

### DIFF
--- a/.github/workflows/deterministic-builds-reusable.yml
+++ b/.github/workflows/deterministic-builds-reusable.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: ""
         type: string
+      runner_labels:
+        description: JSON string or array for the runner selection, for example '"ubuntu-latest"' or '["self-hosted","nightcrawler"]'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
 
 permissions:
   contents: read
@@ -30,7 +35,7 @@ permissions:
 jobs:
   deterministic-builds:
     name: deterministic-builds
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-governance-reusable.yml
+++ b/.github/workflows/docs-governance-reusable.yml
@@ -63,6 +63,11 @@ on:
         required: false
         default: false
         type: boolean
+      runner_labels:
+        description: JSON string or array for the runner selection, for example '"ubuntu-latest"' or '["self-hosted","nightcrawler"]'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
 
 permissions:
   contents: read
@@ -70,7 +75,7 @@ permissions:
 jobs:
   docs-governance:
     name: docs-governance
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Checkout target repository
         uses: actions/checkout@v4

--- a/.github/workflows/policy-standards-reusable.yml
+++ b/.github/workflows/policy-standards-reusable.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: true
         type: boolean
+      runner_labels:
+        description: JSON string or array for the runner selection, for example '"ubuntu-latest"' or '["self-hosted","nightcrawler"]'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
 
 permissions:
   contents: read
@@ -26,7 +31,7 @@ permissions:
 jobs:
   validate:
     name: policy/standards
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     steps:
       - name: Validate PR metadata policy

--- a/.github/workflows/quality-gate-reusable.yml
+++ b/.github/workflows/quality-gate-reusable.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: false
         type: boolean
+      runner_labels:
+        description: JSON string or array for the runner selection, for example '"ubuntu-latest"' or '["self-hosted","nightcrawler"]'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
 
 permissions:
   contents: read
@@ -65,7 +70,7 @@ permissions:
 jobs:
   quality-gate:
     name: quality-gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security-checks-reusable.yml
+++ b/.github/workflows/security-checks-reusable.yml
@@ -19,7 +19,7 @@ on:
         default: true
         type: boolean
       codeql_languages:
-        description: Comma-separated CodeQL languages (supported in baseline: javascript-typescript,python)
+        description: "Comma-separated CodeQL languages (supported in baseline: javascript-typescript,python)"
         required: false
         default: "javascript-typescript,python"
         type: string
@@ -33,6 +33,11 @@ on:
         required: false
         default: high
         type: string
+      runner_labels:
+        description: JSON string or array for the runner selection, for example '"ubuntu-latest"' or '["self-hosted","nightcrawler"]'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
 
 permissions:
   contents: read
@@ -41,7 +46,7 @@ jobs:
   dependency-review:
     name: dependency-review
     if: ${{ inputs.run_dependency_review && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     permissions:
       contents: read
       pull-requests: read
@@ -57,7 +62,7 @@ jobs:
   resolve-codeql-languages:
     name: resolve-codeql-languages
     if: ${{ inputs.run_codeql }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     outputs:
       has_languages: ${{ steps.resolve.outputs.has_languages }}
       languages: ${{ steps.resolve.outputs.languages }}
@@ -129,7 +134,7 @@ jobs:
     name: codeql (${{ matrix.language }})
     needs: resolve-codeql-languages
     if: ${{ inputs.run_codeql && needs.resolve-codeql-languages.outputs.has_languages == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     permissions:
       actions: read
       contents: read
@@ -156,7 +161,7 @@ jobs:
   secret-scan:
     name: secret-scan
     if: ${{ inputs.run_secret_scan }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary
- add a runner_labels workflow_call input to reusable CI workflows
- keep the default on GitHub-hosted ubuntu-latest for backwards compatibility
- allow callers to pass self-hosted labels such as ["self-hosted","nightcrawler","vps-colossus-config"]
- quote an existing CodeQL description that contained an unescaped colon

## Verification
- python YAML parse over .github/workflows/*.yml: ok
- git diff --check: ok

## Related Issue
- Internal CI runner migration for vps-colossus-config

## Checklist
- [x] I confirm this PR title and description are written in English.