### PR TITLE
Update github-script policy action to Node 24

### DIFF
--- a/.github/workflows/policy-standards-reusable.yml
+++ b/.github/workflows/policy-standards-reusable.yml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     steps:
       - name: Validate PR metadata policy
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         env:
           REQUIRE_ISSUE_REFERENCE: ${{ inputs.require_issue_reference }}
           REQUIRE_ENGLISH_CHECKBOX: ${{ inputs.require_english_checkbox }}


### PR DESCRIPTION
## Summary
- update the reusable policy workflow from actions/github-script@v7 to actions/github-script@v9.0.0
- keep the policy script unchanged because it does not use require('@actions/github') or redeclare getOctokit
- remove the organization-level Node.js 20 GitHub Actions warning for policy checks

## Related Issue
Closes #4

## Verification
- git diff --check
- rg -n "actions/github-script@v7|actions/github-script@v8|actions/github-script@v9.0.0" .github/workflows shows only actions/github-script@v9.0.0

## Checklist
- [x] I confirm this PR title and description are written in English.