### PR TITLE
ci(security): add free private-repository SAST mode

### DIFF
--- a/.github/workflow-templates/security-checks.yml
+++ b/.github/workflow-templates/security-checks.yml
@@ -21,9 +21,13 @@ jobs:
   security:
     uses: MDSoftware-DE/.github/.github/workflows/security-checks-reusable.yml@main
     with:
-      run_dependency_review: true
-      run_codeql: true
+      run_dependency_review: false
+      run_codeql: false
+      run_semgrep: true
       run_secret_scan: true
       codeql_languages: "javascript-typescript,python"
+      semgrep_config: "p/default"
+      fail_on_semgrep_findings: true
       fail_on_secret_findings: true
+      upload_gitleaks_sarif: false
       dependency_fail_on_severity: high

--- a/.github/workflows/security-checks-reusable.yml
+++ b/.github/workflows/security-checks-reusable.yml
@@ -9,7 +9,27 @@ on:
         default: true
         type: boolean
       run_codeql:
-        description: Run CodeQL analysis
+        description: Run CodeQL analysis only for public repositories or repositories licensed for GitHub Code Security
+        required: false
+        default: true
+        type: boolean
+      run_semgrep:
+        description: Run free Semgrep Community Edition analysis with local SARIF enforcement
+        required: false
+        default: false
+        type: boolean
+      semgrep_config:
+        description: Semgrep Community Edition registry configuration
+        required: false
+        default: "p/default"
+        type: string
+      fail_on_semgrep_findings:
+        description: Fail the Semgrep job when the locally generated SARIF contains new findings
+        required: false
+        default: true
+        type: boolean
+      upload_gitleaks_sarif:
+        description: Upload gitleaks SARIF only when GitHub Code Security is available
         required: false
         default: true
         type: boolean
@@ -159,6 +179,94 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}"
 
+  semgrep:
+    name: semgrep
+    if: ${{ inputs.run_semgrep }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    container:
+      image: semgrep/semgrep:1.170.0
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify Semgrep SARIF fail control
+        shell: bash
+        run: |
+          set -euo pipefail
+          control_dir="$(mktemp -d)"
+          trap 'rm -rf "${control_dir}"' EXIT
+
+          cat > "${control_dir}/rule.yml" <<'YAML'
+          rules:
+            - id: md-control-eval
+              languages:
+                - python
+              message: Synthetic control finding
+              severity: ERROR
+              pattern: eval(...)
+          YAML
+          printf '%s\n' 'user_input = "control"' 'eval(user_input)' > "${control_dir}/fixture.py"
+          semgrep scan \
+            --config "${control_dir}/rule.yml" \
+            --sarif \
+            --output "${control_dir}/control.sarif" \
+            --metrics off \
+            "${control_dir}/fixture.py"
+          python3 - "${control_dir}/control.sarif" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              report = json.load(handle)
+          findings = sum(len(run.get("results", [])) for run in report.get("runs", []))
+          if findings != 1:
+              raise SystemExit(f"expected exactly one synthetic Semgrep finding, found {findings}")
+          print("Synthetic Semgrep SARIF control: 1 finding")
+          PY
+
+      - name: Run Semgrep CE
+        shell: bash
+        env:
+          SEMGREP_CONFIG: ${{ inputs.semgrep_config }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          args=(
+            scan
+            --config "${SEMGREP_CONFIG}"
+            --sarif
+            --output semgrep.sarif
+            --metrics off
+          )
+          if [[ "${{ github.event_name }}" == "pull_request" && -n "${PR_BASE_SHA}" ]]; then
+            args+=(--baseline-commit "${PR_BASE_SHA}")
+          fi
+          args+=(.)
+          semgrep "${args[@]}"
+
+      - name: Enforce Semgrep SARIF findings
+        if: ${{ always() && hashFiles('semgrep.sarif') != '' }}
+        shell: bash
+        env:
+          FAIL_ON_SEMGREP_FINDINGS: ${{ inputs.fail_on_semgrep_findings }}
+        run: |
+          set -euo pipefail
+          python3 - semgrep.sarif "${FAIL_ON_SEMGREP_FINDINGS}" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              report = json.load(handle)
+          findings = sum(len(run.get("results", [])) for run in report.get("runs", []))
+          print(f"Semgrep findings: {findings}")
+          if sys.argv[2].lower() == "true" and findings:
+              raise SystemExit("Failing due to Semgrep findings.")
+          PY
+
   secret-scan:
     name: secret-scan
     if: ${{ inputs.run_secret_scan }}
@@ -189,7 +297,7 @@ jobs:
           gitleaks dir . --redact --report-format sarif --report-path gitleaks.sarif
 
       - name: Upload SARIF
-        if: ${{ always() && hashFiles('gitleaks.sarif') != '' }}
+        if: ${{ inputs.upload_gitleaks_sarif && always() && hashFiles('gitleaks.sarif') != '' }}
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/docs/codex/CODEX_ORG_STANDARDS.md
+++ b/docs/codex/CODEX_ORG_STANDARDS.md
@@ -129,6 +129,33 @@ erDiagram
   class CALL_EVENT event
 ```
 
+## Security Workflow Operation
+
+### Purpose
+
+Provide a meaningful shared security gate for public, licensed private, and GitHub Free private repositories without treating unavailable paid features as successful checks.
+
+### Current Status Snapshot
+
+- The default wrapper uses Semgrep Community Edition with `p/default` and local SARIF enforcement.
+- Pull requests compare Semgrep findings with the pull request base commit, so new findings fail without silently accepting them.
+- Gitleaks runs and enforces findings locally; SARIF upload is disabled by default.
+- GitHub dependency review and CodeQL remain available as explicit opt-ins for public repositories or private repositories licensed for GitHub Code Security.
+- The default wrapper runs on pull requests and manual dispatch. It does not add a default-branch push trigger, which conserves included GitHub Actions minutes. Dependabot alerts remain the default-branch dependency monitor; manual dispatch performs a full Semgrep scan.
+- No Semgrep account, application token, or paid GitHub security feature is required for the default path.
+
+### Last Change
+
+On 2026-07-16, the shared workflow added a Semgrep Community Edition v1.170.0 path with a synthetic fail control, pull-request baseline comparison, SARIF generation, and local findings enforcement. The wrapper defaults were changed to the free path.
+
+### Quick Test
+
+Open a pull request that introduces a source file matching a `p/default` security rule and verify that `security / semgrep` reports a finding and fails. Remove the finding and verify that the same job passes. Run the workflow manually on the default branch to request a full repository scan.
+
+### Maintenance Rule
+
+Do not enable dependency review, CodeQL, or SARIF uploads for a private repository unless GitHub Code Security entitlement is confirmed. Keep the Semgrep image on an explicit verified release, keep metrics disabled, and preserve both the synthetic fail control and local SARIF enforcement.
+
 ## Enforcement Model
 - Org defaults live in `MDSoftware-DE/.github`.
 - Reusable PR policy workflow source:

--- a/docs/codex/workflows/security-checks.yml
+++ b/docs/codex/workflows/security-checks.yml
@@ -21,9 +21,13 @@ jobs:
   security:
     uses: MDSoftware-DE/.github/.github/workflows/security-checks-reusable.yml@main
     with:
-      run_dependency_review: true
-      run_codeql: true
+      run_dependency_review: false
+      run_codeql: false
+      run_semgrep: true
       run_secret_scan: true
       codeql_languages: "javascript-typescript,python"
+      semgrep_config: "p/default"
+      fail_on_semgrep_findings: true
       fail_on_secret_findings: true
+      upload_gitleaks_sarif: false
       dependency_fail_on_severity: high


### PR DESCRIPTION
## Summary

- Add a free Semgrep Community Edition path that generates SARIF and enforces new pull-request findings locally.
- Keep CodeQL, dependency review, and SARIF upload as explicit opt-ins for public or GitHub Code Security-licensed repositories.
- Default new repository wrappers to Semgrep CE plus local gitleaks enforcement, with no external account or token.
- Document the free private-repository security model and its default-branch strategy.

## Related Issue

- MDSoftware-DE/dgx-spark-vision-config#120

## Verification

- RED contract confirmed the reusable workflow did not expose a Semgrep/SARIF path.
- Semgrep CE v1.170.0 was verified as a real multi-architecture image.
- A read-only full Vision baseline scan generated SARIF: 405 files, 347 rules, 25 pre-existing warning-level findings, no error-level findings.
- GREEN contract verifies each new input declaration and reference, synthetic fail control, pull-request baseline comparison, local SARIF enforcement, synchronized templates, and required workflow documentation.
- Vision PR #119 consumer run 29456055080 passed against this branch:
  - synthetic SARIF fail control: exactly 1 finding;
  - pull-request baseline scan: 0 new findings;
  - local Semgrep SARIF enforcement: passed;
  - local gitleaks enforcement: passed;
  - CodeQL, dependency review, and SARIF upload: skipped as designed.

## Behavior Impact

Private GitHub Free repositories can keep meaningful SAST and secret enforcement without enabling paid GitHub Code Security. The default wrapper remains pull-request plus manual-dispatch only; it does not add a default-branch push trigger or production runtime changes.

## Checklist

- [x] I confirm this PR title and description are written in English.
- [x] I linked related issue(s).
- [x] I documented behavior impact and verification steps.
