### PR TITLE
fix(deterministic-builds): provision pnpm before the setup-node cache step

### DIFF
--- a/.github/workflows/deterministic-builds-reusable.yml
+++ b/.github/workflows/deterministic-builds-reusable.yml
@@ -8,6 +8,14 @@ on:
         required: false
         default: "20"
         type: string
+      pnpm_version:
+        description: >-
+          pnpm version to provision for pnpm repositories. Leave empty (recommended)
+          to use the `packageManager` field in package.json; set it only for repos
+          that have no `packageManager` field. Ignored for npm/yarn repos.
+        required: false
+        default: ""
+        type: string
       enforce_lockfile:
         description: Fail when package.json exists without a supported lockfile
         required: false
@@ -93,6 +101,20 @@ jobs:
             package-lock.json
             npm-shrinkwrap.json
 
+      # pnpm must be on PATH BEFORE the next step: actions/setup-node with `cache: pnpm`
+      # runs `pnpm store path` to locate the cache, so a missing pnpm fails the whole
+      # job with "Unable to locate executable file: pnpm". pnpm/action-setup installs
+      # pnpm to a standalone location and adds it to PATH via GITHUB_PATH, which (unlike
+      # a corepack shim in the system Node's bin dir) survives the Node swap the next
+      # step performs. With an empty `version` the action reads `packageManager` from
+      # package.json (recommended); `pnpm_version` overrides it for repos without that field.
+      - name: Provision pnpm
+        if: ${{ steps.detect.outputs.has_node == 'true' && steps.detect.outputs.manager == 'pnpm' }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ inputs.pnpm_version }}
+          run_install: false
+
       - name: Setup Node.js (pnpm)
         if: ${{ steps.detect.outputs.has_node == 'true' && steps.detect.outputs.manager == 'pnpm' }}
         uses: actions/setup-node@v4
@@ -129,7 +151,7 @@ jobs:
               npm ci
               ;;
             pnpm)
-              corepack enable
+              # pnpm is already on PATH from the "Provision pnpm" step above.
               pnpm install --frozen-lockfile
               ;;
             yarn)


### PR DESCRIPTION
## Summary

`deterministic-builds-reusable.yml` fails for **pnpm** repositories: it runs
`actions/setup-node@v4` with `cache: pnpm` **before** pnpm is on `PATH`. setup-node's
pnpm cache runs `pnpm store path`, so a missing pnpm aborts the whole job with
`Unable to locate executable file: pnpm`.

This never surfaced because **every current adopter has its lockfile in a
subdirectory**, so the detect step reports "no root Node project" and skips the install
path entirely — the Node/pnpm path had effectively never executed in production. The
first repo to actually exercise it (**car24-recruiter**, a pnpm monorepo with a
root-level `pnpm-lock.yaml`) hit the bug on the first run.

## Fix

- Add a **Provision pnpm** step (`pnpm/action-setup@v4`) before the pnpm `setup-node`
  step. It installs pnpm to a standalone location on `GITHUB_PATH`, which survives the
  Node swap `setup-node` performs — a corepack shim in the system Node's bin dir would
  not, which is why simply reordering `corepack enable` is not enough.
- New optional input **`pnpm_version`**: empty (default) reads `packageManager` from
  `package.json` as pnpm recommends; set it for repos without that field.
- Remove the now-redundant `corepack enable` from the pnpm install branch (pnpm is
  already provisioned).
- **npm/yarn paths unchanged.**

## Verification

Verified end-to-end against car24-recruiter (real pnpm monorepo, root lockfile) by
pointing a throwaway caller workflow at this branch with `pnpm_version: "9"`:
the `deterministic-builds` job goes green (lockfile detected, `pnpm install
--frozen-lockfile` succeeds, `verify_lockfile_clean` passes). Before this change the
same call failed at the pnpm cache step.

## Notes

- Related: car24-recruiter#375 (car24 was the only repo still building with
  `--no-frozen-lockfile`; its Dockerfiles + CI now do frozen installs). car24 will
  adopt this reusable workflow once this merges.
- Follow-up worth considering separately: the reusable checks the **CI install** but not
  **Docker image builds** — a Dockerfile can still `--no-frozen-lockfile` past this gate
  (exactly how car24 slipped through). A Dockerfile lint could close that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198a3yAdy3PRKzYLGTn1RtL
