### PR TITLE
fix(security-checks): gitleaks uses a per-run mktemp dir

### DIFF
--- a/.github/workflows/security-checks-reusable.yml
+++ b/.github/workflows/security-checks-reusable.yml
@@ -283,10 +283,12 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="8.24.2"
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tgz
-          tar -xzf /tmp/gitleaks.tgz -C /tmp
+          GL_TMP="$(mktemp -d)"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" -o "$GL_TMP/gitleaks.tgz"
+          tar -xzf "$GL_TMP/gitleaks.tgz" -C "$GL_TMP"
           mkdir -p "$HOME/.local/bin"
-          install -m 0755 /tmp/gitleaks "$HOME/.local/bin/gitleaks"
+          install -m 0755 "$GL_TMP/gitleaks" "$HOME/.local/bin/gitleaks"
+          rm -rf "$GL_TMP"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/gitleaks" version
 


### PR DESCRIPTION
## Summary

The gitleaks secret-scan step in `security-checks-reusable.yml` downloaded and extracted the gitleaks binary to a hardcoded, shared path (`/tmp/gitleaks.tgz`, extracted to `/tmp`, installed from `/tmp/gitleaks`).

On the shared self-hosted Wolverine runner host, multiple runner identities (different unix users, one per onboarded repo) share `/tmp`. When one runner writes `/tmp/gitleaks*` (owned by e.g. `gh-runner`, mode 644), a different runner user (e.g. `gha-etl-mittelhessen`) can then fail with permission-denied (exit 23) trying to overwrite the same fixed path. This makes the secret-scan job spuriously fail for whichever repo's runner loses the race — a multi-tenant collision, not a real problem with the scan itself.

This surfaced while onboarding the `etl-mittelhessen` runner on Wolverine.

## Fix

Use a per-run, uniquely-owned temp directory instead of the fixed `/tmp` path:

- `GL_TMP="$(mktemp -d)"` at the top of the "Install gitleaks" step
- Download to `"$GL_TMP/gitleaks.tgz"`, extract to `"$GL_TMP"`, install the binary from `"$GL_TMP/gitleaks"`
- `rm -rf "$GL_TMP"` once the binary is installed to `$HOME/.local/bin`

Only the download/extract paths changed. The gitleaks version pin (`8.24.2`), the scan command (`gitleaks dir . --redact --report-format sarif ...`), the SARIF upload step, and the findings/exit-code policy enforcement are all untouched.

## Test plan

- [x] Re-parsed the YAML with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security-checks-reusable.yml'))"` — parses cleanly
- [x] Confirmed no remaining `/tmp/gitleaks` references in the file (`grep -n "/tmp/gitleaks"` returns nothing)
- [x] Diffed the change — only the "Install gitleaks" step's path handling changed, 5 insertions / 3 deletions
- [ ] Not runnable here (reusable workflow, no live caller in this session) — static correctness + diff review is the verification for this PR